### PR TITLE
docs: fix typo 'escapse'

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ An example of a custom configuration, showing a range of the different features:
         },
     ],
     "todohighlight.keywordsPattern": "TODO:|FIXME:|\\(([^\\)]+)\\)", //highlight `TODO:`,`FIXME:` or content between parentheses
-    // NOTE: remember to escapse the backslash if there's any in your regexp (using \\\\ instead of single backslash)"
+    // NOTE: remember to escape the backslash if there's any in your regexp (using \\\\ instead of single backslash)"
     "todohighlight.defaultStyle": {
         "color": "red",
         "backgroundColor": "#ffab00",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 									"regex": {
 										"pattern": {
 											"type": "string",
-											"description": "The RegEx pattern to use for matching instead of the text value.REMEMBER to escapse the backslash if there's any in your regexp (using \\\\ instead of single backslash)"
+											"description": "The RegEx pattern to use for matching instead of the text value.REMEMBER to escape the backslash if there's any in your regexp (using \\\\ instead of single backslash)"
 										}
 									},
 									"isWholeLine": {


### PR DESCRIPTION
There are a couple of small typos in README.md and package.json.
Specifically, 'escape' is spelled 'escapse'. This commit corrects
these typos.

Signed-off-by: nschmeller <nick.schmeller@lacework.net>