### PR TITLE
Add note what is not searched

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -187,7 +187,7 @@ function showOutputChannel(data) {
     window.outputChannel.clear();
 
     if (data.length === 0) {
-        window.showInformationMessage('No results');
+        window.showInformationMessage('No results. (Not included file types and individual files are not searched.)');
         return;
     }
 


### PR DESCRIPTION
This does **not** close jgclark#21 but adds a note for all those who do not read the readme carefully.

If preferred, the brackets could also be omitted.