### PR TITLE
Followup: Fix wrong syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,20 +162,20 @@
 							}
 						]
 					},
-					"default": {
-						"TODO:": {
+					"default": [
+						{
 							"text": "TODO:",
 							"color": "#fff",
 							"backgroundColor": "#ffbd2a",
 							"overviewRulerColor": "rgba(255,189,42,0.8)"
 						},
-						"FIXME:": {
+						{
 							"text": "FIXME:",
 							"color": "#fff",
 							"backgroundColor": "#f06292",
 							"overviewRulerColor": "rgba(240,98,146,0.8)"
 						}
-					}
+					]
 				},
 				"todohighlight.keywordsPattern": {
 					"type": "string",
@@ -184,7 +184,7 @@
 				},
 				"todohighlight.defaultStyle": {
 					"type": "object",
-					"description": "Default style for all customized keywords. See all available properties in the [VSCode doc on DecorationRenderOptions](https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions) section.",
+					"markdownDescription": "Default style for all customized keywords. See all available properties in the [VSCode doc on DecorationRenderOptions](https://code.visualstudio.com/api/references/vscode-api#DecorationRenderOptions) section.",
 					"$comment": "The selection of properties for autocompletion are the same as for todohighlight.keywords.",
 					"properties": {
 						"backgroundColor": {


### PR DESCRIPTION
Syntax fixes for #36.
- Fix Markdown description
- object to array (Is an object in the code, but an array in the config and had copied it without checking.)