### PR TITLE
Use onStartupFinished over * activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"main": "./dist/extension",
 	"extensionKind": [


### PR DESCRIPTION
The * activation event slows down startup time and is generally bad practice to use when
another activation event works.

---

See https://code.visualstudio.com/api/references/activation-events#onStartupFinished