### PR TITLE
fix: dispose decoration types before recreation to prevent before/after text duplication

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -171,6 +171,13 @@ function activate(context) {
             window.outputChannel = window.createOutputChannel('TodoHighlight');
         }
 
+        // Dispose of old decoration types before creating new ones
+        if (decorationTypes) {
+            Object.keys(decorationTypes).forEach(key => {
+                decorationTypes[key].dispose();
+            });
+        }
+
         decorationTypes = {};
 
         if (keywordsPattern.trim()) {


### PR DESCRIPTION
This fixes the issue https://github.com/jgclark/vscode-todo-highlight/issues/80